### PR TITLE
404 tracking

### DIFF
--- a/src/Lodestone/Modules/HttpRequest.php
+++ b/src/Lodestone/Modules/HttpRequest.php
@@ -49,7 +49,10 @@ class HttpRequest
         unset($handle);
 
         Logger::write(__CLASS__, __LINE__, 'RESPONSE: '. $httpCode);
-
-        return $data;
+	if ($httpCode == 404) {
+		return 404;
+	} else {
+        	return $data;
+        }
     }
 }

--- a/src/Lodestone/Parser/Achievements.php
+++ b/src/Lodestone/Parser/Achievements.php
@@ -15,17 +15,15 @@ class Achievements extends ParserHelper
      */
     public function parse()
     {
+        if ($this->html == 404) {
+        	return 404;
+        }
         $this->ensureHtml();
         $html = $this->html;
 
         // check if private
         if ($this->isPrivate($html)) {
             return 'private';
-        }
-
-        // check if doesn't exist
-        if ($this->is404($html)) {
-            return false;
         }
 
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');

--- a/src/Lodestone/Parser/Character.php
+++ b/src/Lodestone/Parser/Character.php
@@ -27,13 +27,12 @@ class Character extends ParserHelper
      */
     public function parse($hash = false)
     {
+        if ($this->html == 404) {
+        	return 404;
+        }
         $this->ensureHtml();
         $html = $this->html;
 
-        // check exists
-        if ($this->is404($html)) {
-            return false;
-        }
 
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');
 

--- a/src/Lodestone/Parser/CharacterFollowing.php
+++ b/src/Lodestone/Parser/CharacterFollowing.php
@@ -15,13 +15,11 @@ class CharacterFollowing extends ParserHelper
      */
     public function parse()
     {
+        if ($this->html == 404) {
+        	return 404;
+        }
         $this->ensureHtml();
         $html = $this->html;
-
-        // check exists
-        if ($this->is404($html)) {
-            return false;
-        }
 
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');
         if (!$html) {

--- a/src/Lodestone/Parser/CharacterFriends.php
+++ b/src/Lodestone/Parser/CharacterFriends.php
@@ -15,13 +15,11 @@ class CharacterFriends extends ParserHelper
      */
     public function parse()
     {
+        if ($this->html == 404) {
+        	return 404;
+        }
         $this->ensureHtml();
         $html = $this->html;
-
-        // check exists
-        if ($this->is404($html)) {
-            return false;
-        }
 
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');
         if (!$html) {

--- a/src/Lodestone/Parser/FreeCompany.php
+++ b/src/Lodestone/Parser/FreeCompany.php
@@ -15,13 +15,11 @@ class FreeCompany extends ParserHelper
      */
     public function parse($html = false)
     {
+        if ($this->html == 404) {
+        	return 404;
+        }
         $this->ensureHtml();
         $html = $this->html;
-
-        // check exists
-        if ($this->is404($html)) {
-            return false;
-        }
 
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');
 

--- a/src/Lodestone/Parser/FreeCompanyMembers.php
+++ b/src/Lodestone/Parser/FreeCompanyMembers.php
@@ -15,13 +15,11 @@ class FreeCompanyMembers extends ParserHelper
      */
     public function parse()
     {
+        if ($this->html == 404) {
+        	return 404;
+        }
         $this->ensureHtml();
         $html = $this->html;
-
-        // check exists
-        if ($this->is404($html)) {
-            return false;
-        }
 
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');
 

--- a/src/Lodestone/Parser/Linkshell.php
+++ b/src/Lodestone/Parser/Linkshell.php
@@ -15,13 +15,11 @@ class Linkshell extends ParserHelper
      */
     public function parse()
     {
+        if ($this->html == 404) {
+        	return 404;
+        }
         $this->ensureHtml();
         $html = $this->html;
-
-        // check exists
-        if ($this->is404($html)) {
-            return false;
-        }
 
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');
 

--- a/src/Lodestone/Parser/ParserHelper.php
+++ b/src/Lodestone/Parser/ParserHelper.php
@@ -259,15 +259,6 @@ class ParserHelper
     }
 
     /**
-     * States if a lodestone page is 404 not found.
-     * @return bool
-     */
-    protected function is404($html)
-    {
-        return (stripos($html, 'The page you are searching for has either been removed, or the designated URL address is incorrect.') > -1);
-    }
-
-    /**
      * @param $html
      * @return false|null|string
      */


### PR DESCRIPTION
Use actual headers to track 404 instead of still parsing the page and return 404 if encountered instead of generalized false. Not sure if it's globally useful, but it's useful for my tracker, because I use retries and also want to track if user/company/linkshell got deleted. If I get 404 - it was, if something else - retry. Also, this change may give a very negligible boost to performance. I think.