### PR TITLE
Avoid empty data

### DIFF
--- a/src/Lodestone/Modules/HttpRequest.php
+++ b/src/Lodestone/Modules/HttpRequest.php
@@ -31,37 +31,31 @@ class HttpRequest
      */
     public function get($url)
     {
-        $tries = 0;
-        do {
-	        $url = str_ireplace(' ', '+', $url);
-	        Logger::write(__CLASS__, __LINE__, 'GET: '. $url);
-	
-	        // build handle
-	        $handle = curl_init();
-	        curl_setopt_array($handle, self::CURL_OPTIONS);
-	        curl_setopt($handle, CURLOPT_URL, $url);
-	
-	        // handle response
-	        $response = curl_exec($handle);
-	        $hlength = curl_getinfo($handle, CURLINFO_HEADER_SIZE);
-	        $httpCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
-	        $data = substr($response, $hlength);
-	
-	        curl_close($handle);
-	        unset($handle);
-	
-	        Logger::write(__CLASS__, __LINE__, 'RESPONSE: '. $httpCode);
-		if ($httpCode == 404) {
-			return 404;
-		}
-		if (empty($data)) {
-			$tries++;
-			sleep(5);
-			continue;
-		} else {
-		       	return $data;
-	        }
-        } while($tries < 5);
-        return false;
+        $url = str_ireplace(' ', '+', $url);
+        Logger::write(__CLASS__, __LINE__, 'GET: '. $url);
+
+        // build handle
+        $handle = curl_init();
+        curl_setopt_array($handle, self::CURL_OPTIONS);
+        curl_setopt($handle, CURLOPT_URL, $url);
+
+        // handle response
+        $response = curl_exec($handle);
+        $hlength = curl_getinfo($handle, CURLINFO_HEADER_SIZE);
+        $httpCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
+        $data = substr($response, $hlength);
+
+        curl_close($handle);
+        unset($handle);
+
+        Logger::write(__CLASS__, __LINE__, 'RESPONSE: '. $httpCode);
+	if ($httpCode == 404) {
+		return 404;
+	}
+	if (empty($data)) {
+		return false;
+	} else {
+	       	return $data;
+        }
     }
 }

--- a/src/Lodestone/Modules/HttpRequest.php
+++ b/src/Lodestone/Modules/HttpRequest.php
@@ -31,28 +31,37 @@ class HttpRequest
      */
     public function get($url)
     {
-        $url = str_ireplace(' ', '+', $url);
-        Logger::write(__CLASS__, __LINE__, 'GET: '. $url);
-
-        // build handle
-        $handle = curl_init();
-        curl_setopt_array($handle, self::CURL_OPTIONS);
-        curl_setopt($handle, CURLOPT_URL, $url);
-
-        // handle response
-        $response = curl_exec($handle);
-        $hlength = curl_getinfo($handle, CURLINFO_HEADER_SIZE);
-        $httpCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
-        $data = substr($response, $hlength);
-
-        curl_close($handle);
-        unset($handle);
-
-        Logger::write(__CLASS__, __LINE__, 'RESPONSE: '. $httpCode);
-	if ($httpCode == 404) {
-		return 404;
-	} else {
-        	return $data;
-        }
+        $tries = 0;
+        do {
+	        $url = str_ireplace(' ', '+', $url);
+	        Logger::write(__CLASS__, __LINE__, 'GET: '. $url);
+	
+	        // build handle
+	        $handle = curl_init();
+	        curl_setopt_array($handle, self::CURL_OPTIONS);
+	        curl_setopt($handle, CURLOPT_URL, $url);
+	
+	        // handle response
+	        $response = curl_exec($handle);
+	        $hlength = curl_getinfo($handle, CURLINFO_HEADER_SIZE);
+	        $httpCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
+	        $data = substr($response, $hlength);
+	
+	        curl_close($handle);
+	        unset($handle);
+	
+	        Logger::write(__CLASS__, __LINE__, 'RESPONSE: '. $httpCode);
+		if ($httpCode == 404) {
+			return 404;
+		}
+		if (empty($data)) {
+			$tries++;
+			sleep(5);
+			continue;
+		} else {
+		       	return $data;
+	        }
+        } while($tries < 5);
+        return false;
     }
 }

--- a/src/Lodestone/Parser/Achievements.php
+++ b/src/Lodestone/Parser/Achievements.php
@@ -15,8 +15,8 @@ class Achievements extends ParserHelper
      */
     public function parse()
     {
-        if ($this->html == 404) {
-        	return 404;
+        if ($this->html == 404 || ($this->html == false) {
+        	return $this->html;
         }
         $this->ensureHtml();
         $html = $this->html;

--- a/src/Lodestone/Parser/Achievements.php
+++ b/src/Lodestone/Parser/Achievements.php
@@ -15,10 +15,9 @@ class Achievements extends ParserHelper
      */
     public function parse()
     {
-        if ($this->html == 404 || ($this->html == false) {
+        if ($this->html == 404 || $this->html == false) {
         	return $this->html;
         }
-        $this->ensureHtml();
         $html = $this->html;
 
         // check if private

--- a/src/Lodestone/Parser/Character.php
+++ b/src/Lodestone/Parser/Character.php
@@ -27,8 +27,8 @@ class Character extends ParserHelper
      */
     public function parse($hash = false)
     {
-        if ($this->html == 404) {
-        	return 404;
+        if ($this->html == 404 || ($this->html == false) {
+        	return $this->html;
         }
         $this->ensureHtml();
         $html = $this->html;

--- a/src/Lodestone/Parser/Character.php
+++ b/src/Lodestone/Parser/Character.php
@@ -27,10 +27,9 @@ class Character extends ParserHelper
      */
     public function parse($hash = false)
     {
-        if ($this->html == 404 || ($this->html == false) {
+        if ($this->html == 404 || $this->html == false)) {
         	return $this->html;
         }
-        $this->ensureHtml();
         $html = $this->html;
 
 

--- a/src/Lodestone/Parser/Character.php
+++ b/src/Lodestone/Parser/Character.php
@@ -27,7 +27,7 @@ class Character extends ParserHelper
      */
     public function parse($hash = false)
     {
-        if ($this->html == 404 || $this->html == false)) {
+        if ($this->html == 404 || $this->html == false) {
         	return $this->html;
         }
         $html = $this->html;

--- a/src/Lodestone/Parser/CharacterFollowing.php
+++ b/src/Lodestone/Parser/CharacterFollowing.php
@@ -15,10 +15,9 @@ class CharacterFollowing extends ParserHelper
      */
     public function parse()
     {
-        if ($this->html == 404 || ($this->html == false) {
+        if ($this->html == 404 || $this->html == false) {
         	return $this->html;
         }
-        $this->ensureHtml();
         $html = $this->html;
 
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');

--- a/src/Lodestone/Parser/CharacterFollowing.php
+++ b/src/Lodestone/Parser/CharacterFollowing.php
@@ -15,8 +15,8 @@ class CharacterFollowing extends ParserHelper
      */
     public function parse()
     {
-        if ($this->html == 404) {
-        	return 404;
+        if ($this->html == 404 || ($this->html == false) {
+        	return $this->html;
         }
         $this->ensureHtml();
         $html = $this->html;

--- a/src/Lodestone/Parser/CharacterFriends.php
+++ b/src/Lodestone/Parser/CharacterFriends.php
@@ -15,8 +15,8 @@ class CharacterFriends extends ParserHelper
      */
     public function parse()
     {
-        if ($this->html == 404) {
-        	return 404;
+        if ($this->html == 404 || ($this->html == false) {
+        	return $this->html;
         }
         $this->ensureHtml();
         $html = $this->html;

--- a/src/Lodestone/Parser/CharacterFriends.php
+++ b/src/Lodestone/Parser/CharacterFriends.php
@@ -15,10 +15,9 @@ class CharacterFriends extends ParserHelper
      */
     public function parse()
     {
-        if ($this->html == 404 || ($this->html == false) {
+        if ($this->html == 404 || $this->html == false) {
         	return $this->html;
         }
-        $this->ensureHtml();
         $html = $this->html;
 
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');

--- a/src/Lodestone/Parser/FreeCompany.php
+++ b/src/Lodestone/Parser/FreeCompany.php
@@ -15,8 +15,8 @@ class FreeCompany extends ParserHelper
      */
     public function parse($html = false)
     {
-        if ($this->html == 404) {
-        	return 404;
+        if ($this->html == 404 || ($this->html == false) {
+        	return $this->html;
         }
         $this->ensureHtml();
         $html = $this->html;

--- a/src/Lodestone/Parser/FreeCompany.php
+++ b/src/Lodestone/Parser/FreeCompany.php
@@ -15,10 +15,9 @@ class FreeCompany extends ParserHelper
      */
     public function parse($html = false)
     {
-        if ($this->html == 404 || ($this->html == false) {
+        if ($this->html == 404 || $this->html == false) {
         	return $this->html;
         }
-        $this->ensureHtml();
         $html = $this->html;
 
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');

--- a/src/Lodestone/Parser/FreeCompanyMembers.php
+++ b/src/Lodestone/Parser/FreeCompanyMembers.php
@@ -15,8 +15,8 @@ class FreeCompanyMembers extends ParserHelper
      */
     public function parse()
     {
-        if ($this->html == 404) {
-        	return 404;
+        if ($this->html == 404 || ($this->html == false) {
+        	return $this->html;
         }
         $this->ensureHtml();
         $html = $this->html;

--- a/src/Lodestone/Parser/FreeCompanyMembers.php
+++ b/src/Lodestone/Parser/FreeCompanyMembers.php
@@ -15,10 +15,9 @@ class FreeCompanyMembers extends ParserHelper
      */
     public function parse()
     {
-        if ($this->html == 404 || ($this->html == false) {
+        if ($this->html == 404 || $this->html == false) {
         	return $this->html;
         }
-        $this->ensureHtml();
         $html = $this->html;
 
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');

--- a/src/Lodestone/Parser/Linkshell.php
+++ b/src/Lodestone/Parser/Linkshell.php
@@ -15,10 +15,9 @@ class Linkshell extends ParserHelper
      */
     public function parse()
     {
-        if ($this->html == 404 || ($this->html == false) {
+        if ($this->html == 404 || $this->html == false) {
         	return $this->html;
         }
-        $this->ensureHtml();
         $html = $this->html;
 
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');

--- a/src/Lodestone/Parser/Linkshell.php
+++ b/src/Lodestone/Parser/Linkshell.php
@@ -15,8 +15,8 @@ class Linkshell extends ParserHelper
      */
     public function parse()
     {
-        if ($this->html == 404) {
-        	return 404;
+        if ($this->html == 404 || ($this->html == false) {
+        	return $this->html;
         }
         $this->ensureHtml();
         $html = $this->html;

--- a/src/Lodestone/Parser/Lodestone.php
+++ b/src/Lodestone/Parser/Lodestone.php
@@ -27,7 +27,9 @@ class Lodestone extends ParserHelper
      */
     public function parseBanners()
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
         $this->setInitialDocument($html);
@@ -51,7 +53,9 @@ class Lodestone extends ParserHelper
      */
     public function parseTopics()
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');
@@ -79,7 +83,9 @@ class Lodestone extends ParserHelper
      */
     public function parseNotices()
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');
@@ -105,7 +111,9 @@ class Lodestone extends ParserHelper
      */
     public function parseMaintenance()
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');
@@ -136,7 +144,9 @@ class Lodestone extends ParserHelper
      */
     public function parseUpdates()
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');
@@ -162,7 +172,9 @@ class Lodestone extends ParserHelper
      */
     public function parseStatus()
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');
@@ -193,7 +205,9 @@ class Lodestone extends ParserHelper
      */
     public function parseWorldStatus()
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');
@@ -218,7 +232,9 @@ class Lodestone extends ParserHelper
      */
     public function parseFeast()
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
         $this->setInitialDocument($html);
@@ -255,7 +271,9 @@ class Lodestone extends ParserHelper
      */
     public function parseDeepDungeon()
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
         $this->setInitialDocument($html);
@@ -311,7 +329,9 @@ class Lodestone extends ParserHelper
      */
     public function parseDevTrackingUrl($lang = 'en')
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
 
@@ -333,7 +353,9 @@ class Lodestone extends ParserHelper
      */
     public function parseDevPostLinks()
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
 
@@ -354,7 +376,9 @@ class Lodestone extends ParserHelper
      */
     public function parseDevPost($postId)
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
         $this->setInitialDocument($html);

--- a/src/Lodestone/Parser/ParserHelper.php
+++ b/src/Lodestone/Parser/ParserHelper.php
@@ -42,16 +42,6 @@ class ParserHelper
     }
 
     /**
-     * @throws \Exception
-     */
-    protected function ensureHtml()
-    {
-        if (!$this->html) {
-            throw new \Exception('HTML not set, please run $parser->url() first');
-        }
-    }
-
-    /**
      * Get a new document
      * @param $html
      * @return Document

--- a/src/Lodestone/Parser/Search.php
+++ b/src/Lodestone/Parser/Search.php
@@ -13,7 +13,9 @@ class Search extends ParserHelper
      */
     public function parseCharacterSearch()
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');
@@ -48,7 +50,9 @@ class Search extends ParserHelper
      */
     public function parseFreeCompanySearch()
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');
@@ -88,7 +92,9 @@ class Search extends ParserHelper
      */
     public function parseLinkshellSearch()
     {
-        $this->ensureHtml();
+        if ($this->html == 404 || $this->html == false) {
+        	return $this->html;
+        }
 
         $html = $this->html;
         $html = $this->trim($html, 'class="ldst__main"', 'class="ldst__side"');


### PR DESCRIPTION
Added up to 5 tries in case $data is empty to counter occasional empty pages being processed. If nothing is grabbed and it was not 404 - return regular false, since we can't determine what is the actual cause.