### PR TITLE
chore(gear): move initialization into IF-constructs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "symfony/css-selector",
-            "version": "v3.2.8",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "02983c144038e697c959e6b06ef6666de759ccbc"
+                "reference": "4d882dced7b995d5274293039370148e291808f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/02983c144038e697c959e6b06ef6666de759ccbc",
-                "reference": "02983c144038e697c959e6b06ef6666de759ccbc",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/4d882dced7b995d5274293039370148e291808f2",
+                "reference": "4d882dced7b995d5274293039370148e291808f2",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -57,7 +57,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2017-05-01T14:55:58+00:00"
+            "time": "2017-05-01T15:01:29+00:00"
         }
     ],
     "packages-dev": [
@@ -720,16 +720,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.1.3",
+            "version": "6.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "824d02024916525a36b2db21847a5ef91db9e4a8"
+                "reference": "16999a1e9a8a25d68f0ab8cc8ab818b043ad5374"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/824d02024916525a36b2db21847a5ef91db9e4a8",
-                "reference": "824d02024916525a36b2db21847a5ef91db9e4a8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/16999a1e9a8a25d68f0ab8cc8ab818b043ad5374",
+                "reference": "16999a1e9a8a25d68f0ab8cc8ab818b043ad5374",
                 "shasum": ""
             },
             "require": {
@@ -749,8 +749,8 @@
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "^4.0",
                 "sebastian/comparator": "^2.0",
-                "sebastian/diff": "^1.2",
-                "sebastian/environment": "^3.0.1",
+                "sebastian/diff": "^1.4.3 || ^2.0",
+                "sebastian/environment": "^3.0.2",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^1.1 || ^2.0",
                 "sebastian/object-enumerator": "^3.0.2",
@@ -774,7 +774,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1.x-dev"
+                    "dev-master": "6.2.x-dev"
                 }
             },
             "autoload": {
@@ -800,7 +800,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-29T10:40:17+00:00"
+            "time": "2017-06-02T12:24:37+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -972,23 +972,23 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -1020,20 +1020,20 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "11e7710b7724d42c62249b0e9d3030240398949d"
+                "reference": "02b6b2c7aefe2cdb1185b8dbf8718b0bcedf3ab3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/11e7710b7724d42c62249b0e9d3030240398949d",
-                "reference": "11e7710b7724d42c62249b0e9d3030240398949d",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/02b6b2c7aefe2cdb1185b8dbf8718b0bcedf3ab3",
+                "reference": "02b6b2c7aefe2cdb1185b8dbf8718b0bcedf3ab3",
                 "shasum": ""
             },
             "require": {
@@ -1070,7 +1070,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-04-21T14:40:32+00:00"
+            "time": "2017-05-18T10:10:00+00:00"
         },
         {
             "name": "sebastian/exporter",

--- a/src/Lodestone/Entities/AbstractEntity.php
+++ b/src/Lodestone/Entities/AbstractEntity.php
@@ -13,28 +13,6 @@ use Lodestone\Validator\BaseValidator;
 class AbstractEntity
 {
     /**
-     * @var BaseValidator
-     */
-    protected $validator;
-
-    /**
-     * AbstractEntity constructor.
-     */
-    public function __construct()
-    {
-        $this->initializeValidator();
-    }
-
-    /**
-     * @return $this
-     */
-    protected function initializeValidator()
-    {
-        $this->validator = new BaseValidator();
-        return $this;
-    }
-
-    /**
      * Map all class attributes
      *
      * @return array

--- a/src/Lodestone/Entities/Character/Attribute.php
+++ b/src/Lodestone/Entities/Character/Attribute.php
@@ -3,6 +3,7 @@
 namespace Lodestone\Entities\Character;
 
 use Lodestone\Entities\AbstractEntity;
+use Lodestone\Validator\BaseValidator;
 
 /**
  * Class Attribute
@@ -36,6 +37,7 @@ class Attribute extends AbstractEntity
 
     /**
      * @param int $id
+     * @return $this
      */
     public function setId($id)
     {
@@ -53,10 +55,11 @@ class Attribute extends AbstractEntity
 
     /**
      * @param string $name
+     * @return $this
      */
     public function setName(string $name)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($name, 'Attribute Name')
             ->isInitialized()
             ->isString()
@@ -76,10 +79,11 @@ class Attribute extends AbstractEntity
 
     /**
      * @param int $value
+     * @return $this
      */
     public function setValue(int $value)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($value, 'Attribute Value')
             ->isInitialized()
             ->isNumeric()

--- a/src/Lodestone/Entities/Character/City.php
+++ b/src/Lodestone/Entities/Character/City.php
@@ -3,6 +3,7 @@
 namespace Lodestone\Entities\Character;
 
 use Lodestone\Entities\AbstractEntity;
+use Lodestone\Validator\BaseValidator;
 
 /**
  * Class City
@@ -58,7 +59,7 @@ class City extends AbstractEntity
      */
     public function setName(string $name)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($name, 'Name')
             ->isInitialized()
             ->isNotEmpty()
@@ -84,7 +85,7 @@ class City extends AbstractEntity
      */
     public function setIcon(string $icon)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($icon, 'Icon URL')
             ->isInitialized()
             ->isNotEmpty()

--- a/src/Lodestone/Entities/Character/ClassJob.php
+++ b/src/Lodestone/Entities/Character/ClassJob.php
@@ -3,6 +3,7 @@
 namespace Lodestone\Entities\Character;
 
 use Lodestone\Entities\AbstractEntity;
+use Lodestone\Validator\BaseValidator;
 
 /**
  * Class ClassJob
@@ -66,6 +67,7 @@ class ClassJob extends AbstractEntity
 
     /**
      * @param int $id
+     * @return $this
      */
     public function setId($id)
     {
@@ -83,10 +85,11 @@ class ClassJob extends AbstractEntity
 
     /**
      * @param string $name
+     * @return $this
      */
     public function setName(string $name)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($name, 'Name')
             ->isInitialized()
             ->isNotEmpty()
@@ -106,10 +109,11 @@ class ClassJob extends AbstractEntity
 
     /**
      * @param int $level
+     * @return $this
      */
     public function setLevel(int $level)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($level, 'Level')
             ->isInitialized()
             ->isNotEmpty()
@@ -130,6 +134,7 @@ class ClassJob extends AbstractEntity
 
     /**
      * @param int $expLevel
+     * @return $this
      */
     public function setExpLevel(int $expLevel)
     {
@@ -147,6 +152,7 @@ class ClassJob extends AbstractEntity
 
     /**
      * @param int $expLevelTogo
+     * @return $this
      */
     public function setExpLevelTogo(int $expLevelTogo)
     {
@@ -164,6 +170,7 @@ class ClassJob extends AbstractEntity
 
     /**
      * @param int $expLevelMax
+     * @return $this
      */
     public function setExpLevelMax(int $expLevelMax)
     {
@@ -181,6 +188,7 @@ class ClassJob extends AbstractEntity
 
     /**
      * @param int $expTotal
+     * @return $this
      */
     public function setExpTotal(int $expTotal)
     {
@@ -198,6 +206,7 @@ class ClassJob extends AbstractEntity
 
     /**
      * @param int $expTotalMax
+     * @return $this
      */
     public function setExpTotalMax(int $expTotalMax)
     {
@@ -215,6 +224,7 @@ class ClassJob extends AbstractEntity
 
     /**
      * @param int $expTotalTogo
+     * @return $this
      */
     public function setExpTotalTogo(int $expTotalTogo)
     {

--- a/src/Lodestone/Entities/Character/Collectable.php
+++ b/src/Lodestone/Entities/Character/Collectable.php
@@ -3,6 +3,7 @@
 namespace Lodestone\Entities\Character;
 
 use Lodestone\Entities\AbstractEntity;
+use Lodestone\Validator\BaseValidator;
 
 /**
  * Class Collectable
@@ -27,6 +28,7 @@ class Collectable extends AbstractEntity
      */
     public function setId($id)
     {
+        $this->id = $id;
         return $this;
     }
 
@@ -36,7 +38,7 @@ class Collectable extends AbstractEntity
      */
     public function setName(string $name)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($name, 'Name')
             ->isInitialized()
             ->isNotEmpty()

--- a/src/Lodestone/Entities/Character/Collectables.php
+++ b/src/Lodestone/Entities/Character/Collectables.php
@@ -3,6 +3,7 @@
 namespace Lodestone\Entities\Character;
 
 use Lodestone\Entities\AbstractEntity;
+use Lodestone\Validator\BaseValidator;
 
 /**
  * Class Collectables
@@ -31,10 +32,11 @@ class Collectables extends AbstractEntity
 
     /**
      * @param array $minions
+     * @return $this
      */
     public function setMinions(array $minions)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($minions, 'Minions array')
             ->isInitialized()
             ->isArray()
@@ -64,10 +66,11 @@ class Collectables extends AbstractEntity
 
     /**
      * @param array $mounts
+     * @return $this
      */
     public function setMounts(array $mounts)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($mounts, 'Mounts array')
             ->isInitialized()
             ->isArray()

--- a/src/Lodestone/Entities/Character/GrandCompany.php
+++ b/src/Lodestone/Entities/Character/GrandCompany.php
@@ -3,6 +3,7 @@
 namespace Lodestone\Entities\Character;
 
 use Lodestone\Entities\AbstractEntity;
+use Lodestone\Validator\BaseValidator;
 
 /**
  * Class GrandCompany
@@ -45,6 +46,7 @@ class GrandCompany extends AbstractEntity
      */
     public function setId($id)
     {
+        $this->id = $id;
         return $this;
     }
 
@@ -62,7 +64,7 @@ class GrandCompany extends AbstractEntity
      */
     public function setName(string $name)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($name, 'Name')
             ->isInitialized()
             ->isNotEmpty()
@@ -87,7 +89,7 @@ class GrandCompany extends AbstractEntity
      */
     public function setIcon(string $icon)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($icon, 'Icon URL')
             ->isInitialized()
             ->isNotEmpty()
@@ -113,7 +115,7 @@ class GrandCompany extends AbstractEntity
      */
     public function setRank(string $rank)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($rank, 'Rank')
             ->isInitialized()
             ->isNotEmpty()

--- a/src/Lodestone/Entities/Character/Guardian.php
+++ b/src/Lodestone/Entities/Character/Guardian.php
@@ -3,6 +3,7 @@
 namespace Lodestone\Entities\Character;
 
 use Lodestone\Entities\AbstractEntity;
+use Lodestone\Validator\BaseValidator;
 
 /**
  * Class Guardian
@@ -58,7 +59,7 @@ class Guardian extends AbstractEntity
      */
     public function setName(string $name)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($name, 'Name')
             ->isInitialized()
             ->isNotEmpty()
@@ -84,7 +85,7 @@ class Guardian extends AbstractEntity
      */
     public function setIcon(string $icon)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($icon, 'Icon URL')
             ->isInitialized()
             ->isNotEmpty()

--- a/src/Lodestone/Entities/Character/Item.php
+++ b/src/Lodestone/Entities/Character/Item.php
@@ -3,6 +3,7 @@
 namespace Lodestone\Entities\Character;
 
 use Lodestone\Entities\AbstractEntity;
+use Lodestone\Validator\BaseValidator;
 
 /**
  * Class Item
@@ -66,6 +67,7 @@ class Item extends AbstractEntity
 
     /**
      * @param int $id
+     * @return $this
      */
     public function setId($id)
     {
@@ -86,10 +88,11 @@ class Item extends AbstractEntity
 
     /**
      * @param string $lodestoneId
+     * @return $this
      */
     public function setLodestoneId(string $lodestoneId)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($lodestoneId, 'Item Lodestone ID')
             ->isInitialized()
             ->isString()
@@ -109,10 +112,11 @@ class Item extends AbstractEntity
 
     /**
      * @param string $name
+     * @return $this
      */
     public function setName(string $name)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($name, 'Item Name')
             ->isInitialized()
             ->isNotEmpty()
@@ -133,10 +137,11 @@ class Item extends AbstractEntity
 
     /**
      * @param string $slot
+     * @return $this
      */
     public function setSlot(string $slot)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($slot, 'Item Slot')
             ->isInitialized()
             ->isNotEmpty()
@@ -157,10 +162,11 @@ class Item extends AbstractEntity
 
     /**
      * @param string $category
+     * @return $this
      */
     public function setCategory(string $category)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($category, 'Item Category')
             ->isInitialized()
             ->isStringOrEmpty()
@@ -171,7 +177,7 @@ class Item extends AbstractEntity
     }
 
     /**
-     * @return string
+     * @return int
      */
     public function getMirageId(): int
     {
@@ -180,11 +186,12 @@ class Item extends AbstractEntity
 
     /**
      * @param string $mirageId
+     * @return $this
      */
     public function setMirageId(string $mirageId)
     {
         // can be empty
-        $this->validator
+        BaseValidator::getInstance()
             ->check($mirageId, 'Item mirage')
             ->isInitialized()
             ->isStringOrEmpty()
@@ -204,11 +211,12 @@ class Item extends AbstractEntity
 
     /**
      * @param int $creatorId
+     * @return $this
      */
     public function setCreatorId(int $creatorId)
     {
         // can be empty
-        $this->validator
+        BaseValidator::getInstance()
             ->check($creatorId, 'Item Creator')
             ->isInitialized()
             ->isNumeric()
@@ -228,10 +236,11 @@ class Item extends AbstractEntity
 
     /**
      * @param string $dyeId
+     * @return $this
      */
     public function setDyeId(string $dyeId)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($dyeId, 'Item Dye')
             ->isInitialized()
             ->isStringOrEmpty()
@@ -251,10 +260,11 @@ class Item extends AbstractEntity
 
     /**
      * @param array $materia
+     * @return $this
      */
     public function setMateria(array $materia)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($materia, 'Materia Array (replace)')
             ->isInitialized()
             ->isArray()
@@ -270,7 +280,7 @@ class Item extends AbstractEntity
      */
     public function addMateria(array $materia)
     {
-        $this->validator
+        BaseValidator::getInstance()
             ->check($materia, 'Materia Array (add)')
             ->isInitialized()
             ->isArray()

--- a/src/Lodestone/Entities/Character/Profile.php
+++ b/src/Lodestone/Entities/Character/Profile.php
@@ -124,9 +124,8 @@ class Profile extends AbstractEntity
      */
     public function __construct($id)
     {
-        parent::__construct();
 
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($id, 'ID')
             ->isInitialized()
             ->isNotEmpty()
@@ -134,9 +133,6 @@ class Profile extends AbstractEntity
             ->validate();
 
         $this->id = $id;
-
-        /** @var CharacterValidator $this->validator */
-        $this->validator = new CharacterValidator();
 
         // profile classes
         $this->collectables = new Collectables();
@@ -182,7 +178,7 @@ class Profile extends AbstractEntity
      */
     public function setName(string $name)
     {
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($name, 'Name')
             ->isInitialized()
             ->isNotEmpty()
@@ -209,7 +205,7 @@ class Profile extends AbstractEntity
      */
     public function setServer(string $server)
     {
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($server, 'Server')
             ->isInitialized()
             ->isNotEmpty()
@@ -234,7 +230,7 @@ class Profile extends AbstractEntity
      */
     public function setTitle($title)
     {
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($title, 'Title')
             ->isInitialized()
             ->isNotEmpty()
@@ -260,7 +256,7 @@ class Profile extends AbstractEntity
      */
     public function setAvatar(string $avatar)
     {
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($avatar, 'Avatar URL')
             ->isInitialized()
             ->isNotEmpty()
@@ -286,7 +282,7 @@ class Profile extends AbstractEntity
      */
     public function setPortrait(string $portrait)
     {
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($portrait, 'Portrait URL')
             ->isInitialized()
             ->isNotEmpty()
@@ -312,7 +308,7 @@ class Profile extends AbstractEntity
      */
     public function setBiography(string $biography)
     {
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($biography, 'Biography')
             ->isInitialized()
             ->isStringOrEmpty()
@@ -337,7 +333,7 @@ class Profile extends AbstractEntity
      */
     public function setRace(string $race)
     {
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($race, 'Race')
             ->isInitialized()
             ->isNotEmpty()
@@ -363,7 +359,7 @@ class Profile extends AbstractEntity
      */
     public function setClan(string $clan)
     {
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($clan, 'Clan')
             ->isInitialized()
             ->isNotEmpty()
@@ -389,7 +385,7 @@ class Profile extends AbstractEntity
      */
     public function setGender(string $gender)
     {
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($gender, 'Gender')
             ->isInitialized()
             ->isNotEmpty()
@@ -415,7 +411,7 @@ class Profile extends AbstractEntity
      */
     public function setNameday(string $nameday)
     {
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($nameday, 'Nameday')
             ->isInitialized()
             ->isNotEmpty()
@@ -441,7 +437,7 @@ class Profile extends AbstractEntity
      */
     public function setGuardian(Guardian $guardian)
     {
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($guardian, 'Guardian')
             ->isInitialized()
             ->validate();
@@ -465,7 +461,7 @@ class Profile extends AbstractEntity
      */
     public function setCity(City $city)
     {
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($city, 'City')
             ->isInitialized()
             ->validate();
@@ -489,7 +485,7 @@ class Profile extends AbstractEntity
      */
     public function setGrandcompany($grandcompany)
     {
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($grandcompany, 'Grand Company')
             ->isInitialized()
             ->validate();
@@ -513,7 +509,7 @@ class Profile extends AbstractEntity
      */
     public function setFreecompany($freecompany)
     {
-        $this->validator
+        CharacterValidator::getInstance()
             ->check($freecompany, 'Free Company')
             ->isInitialized()
             ->isNotEmpty()

--- a/src/Lodestone/Modules/HttpRequest.php
+++ b/src/Lodestone/Modules/HttpRequest.php
@@ -56,8 +56,8 @@ class HttpRequest
         Logger::write(__CLASS__, __LINE__, 'RESPONSE: '. $httpCode);
 
         // specific conditions to return code on
-        $validator = new HttpRequestValidator($httpCode, 'HTTP Response Code');
-        $validator
+        HttpRequestValidator::getInstance()
+            ->check($httpCode, 'HTTP Response Code')
             ->isNotHttpError()
             ->validate();
 

--- a/src/Lodestone/Parser/Character/TraitGear.php
+++ b/src/Lodestone/Parser/Character/TraitGear.php
@@ -40,39 +40,40 @@ trait TraitGear
             $item->setCategory(trim($category));
 
             // add mirage
-            $mirageId = false;
             $mirageNode = $node->find('.db-tooltip__item__mirage');
             if ($mirageNode) {
                 $mirageNode = $mirageNode->find('a', 0);
                 if ($mirageNode) {
                     $mirageId = explode('/', $mirageNode->getAttribute('href'))[5];
+                    $item->setMirageId($mirageId);
                     // todo - parse name and convert to ingame id
+
                 }
             }
-            $item->setMirageId($mirageId);
+
 
             // add creator
-            $creatorId = false;
             $creatorNode = $node->find('.db-tooltip__signature-character');
             if ($creatorNode) {
                 $creatorNode = $creatorNode->find('a',0);
                 if ($creatorNode) {
                     $creatorId = explode('/', $creatorNode->getAttribute('href'))[3];
+                    $item->setCreatorId($creatorId);
                 }
             }
-            $item->setCreatorId($creatorId);
+
 
             // add dye
-            $dyeId = false;
             $dyeNode = $node->find('.stain');
             if ($dyeNode) {
                 $dyeNode = $dyeNode->find('a',0);
                 if ($dyeNode) {
                     $dyeId = explode('/', $dyeNode->getAttribute('href'))[5];
+                    $item->setDyeId($dyeId);
                     // todo - parse name and convert to ingame id
                 }
             }
-            $item->setDyeId($dyeId);
+
 
             // add materia
             $materiaNodes = $node->find('.db-tooltip__materia',0);

--- a/src/Lodestone/Parser/ParserHelper.php
+++ b/src/Lodestone/Parser/ParserHelper.php
@@ -60,8 +60,8 @@ class ParserHelper
      */
     protected function ensureHtml()
     {
-        $validator = new BaseValidator($this->html, "HTML");
-        $validator
+        BaseValidator::getInstance()
+            ->check($this->html, "HTML")
             ->isInitialized()
             ->validate();
     }

--- a/src/Lodestone/Validator/BaseValidator.php
+++ b/src/Lodestone/Validator/BaseValidator.php
@@ -15,19 +15,32 @@ class BaseValidator
     public $name;
     public $errors;
 
+    private static $instance = null;
+
+    public static function getInstance() {
+        if (null === self::$instance) {
+            self::$instance = new BaseValidator();
+        }
+
+        return self::$instance;
+    }
+
     /**
      * BaseValidator constructor.
      *
-     * @param $object
-     * @param $name
      */
-    public function __construct($object = null, $name = null)
+    protected function __construct()
     {
-        $this->check($object, $name);
         $this->errors = [];
     }
 
-  /**
+
+    /**
+     * Is not allowed for a singleton
+     */
+    protected function __clone() {}
+
+    /**
    * @param $object
    * @param $name
    * @return $this

--- a/src/Lodestone/Validator/BaseValidator.php
+++ b/src/Lodestone/Validator/BaseValidator.php
@@ -161,10 +161,13 @@ class BaseValidator
      */
     public function validate()
     {
-        if (count($this->errors) > 0) {
+        $errors = $this->errors;
+        $this->errors = [];
+
+        if (count($errors) > 0) {
             // only throw one exception at a time.
             // Maybe this can be improved to stack exceptions
-            throw $this->errors[0];
+            throw $errors[0];
         }
 
         return true;

--- a/src/Lodestone/Validator/CharacterValidator.php
+++ b/src/Lodestone/Validator/CharacterValidator.php
@@ -10,10 +10,20 @@ class CharacterValidator extends BaseValidator
 {
     const VALID_CHARACTER_REGEX = '/^[a-zA-Z\' \-]+\s?$/';
 
+    private static $instance = null;
+
+    public static function getInstance() {
+        if (null === self::$instance) {
+            self::$instance = new CharacterValidator();
+        }
+
+        return self::$instance;
+    }
+
     /**
      * CharacterValidator constructor.
      */
-    public function __construct()
+    protected function __construct()
     {
         parent::__construct();
     }

--- a/src/Lodestone/Validator/HttpRequestValidator.php
+++ b/src/Lodestone/Validator/HttpRequestValidator.php
@@ -11,14 +11,22 @@ class HttpRequestValidator extends BaseValidator
     const HTTP_OK = 200;
     const HTTP_PERM_REDIRECT = 308;
 
+    private static $instance = null;
+
+    public static function getInstance() {
+        if (null === self::$instance) {
+            self::$instance = new HttpRequestValidator();
+        }
+
+        return self::$instance;
+    }
+
     /**
     * HttpRequestValidator constructor.
-    * @param $object
-    * @param $name
     */
-    public function __construct($object, $name)
+    protected function __construct()
     {
-        parent::__construct($object, $name);
+        parent::__construct();
     }
 
     /**

--- a/tests/Lodestone/Validator/BaseValidatorTest.php
+++ b/tests/Lodestone/Validator/BaseValidatorTest.php
@@ -20,11 +20,9 @@ class BaseValidatorTest extends TestCase
      */
     public function testIsInitialized()
     {
-        // given
-        $validator = new BaseValidator('', $this->name);
-
         // when
-        $result = $validator
+        $result = BaseValidator::getInstance()
+            ->check('', $this->name)
             ->isInitialized()
             ->validate();
 
@@ -36,12 +34,10 @@ class BaseValidatorTest extends TestCase
      */
     public function testIsInitializedWithNullValue()
     {
-        // given
-        $validator = new BaseValidator(null, $this->name);
-
         try {
             // when
-            $validator
+            BaseValidator::getInstance()
+                ->check(null, $this->name)
                 ->isInitialized()
                 ->validate();
 
@@ -58,10 +54,10 @@ class BaseValidatorTest extends TestCase
     {
         // given
         $string = 'le test';
-        $validator = new BaseValidator($string, $this->name);
 
         // when
-        $result = $validator
+        $result = BaseValidator::getInstance()
+            ->check($string, $this->name)
             ->isNotEmpty()
             ->validate();
 
@@ -76,11 +72,11 @@ class BaseValidatorTest extends TestCase
     {
         // given
         $string = '';
-        $validator = new BaseValidator($string, $this->name);
 
         // when
         try {
-            $validator
+            BaseValidator::getInstance()
+                ->check($string, $this->name)
                 ->isNotEmpty()
                 ->validate();
 
@@ -98,10 +94,10 @@ class BaseValidatorTest extends TestCase
     {
         // given
         $string = '';
-        $validator = new BaseValidator($string, $this->name);
 
         // when
-        $result = $validator
+        $result = BaseValidator::getInstance()
+            ->check($string, $this->name)
             ->isString()
             ->validate();
 
@@ -115,11 +111,11 @@ class BaseValidatorTest extends TestCase
     {
         // given
         $value = 1;
-        $validator = new BaseValidator($value, $this->name);
 
         try {
             // when
-            $validator
+            BaseValidator::getInstance()
+                ->check($value, $this->name)
                 ->isString()
                 ->validate();
 
@@ -138,10 +134,12 @@ class BaseValidatorTest extends TestCase
     {
         // given
         $value = '';
-        $validator = new BaseValidator($value, 'Empty String');
 
         // when
-        $result = $validator->isString()->validate();
+        $result = BaseValidator::getInstance()
+            ->check($value, 'Empty String')
+            ->isString()
+            ->validate();
 
         // then
         self::assertTrue($result);
@@ -154,11 +152,11 @@ class BaseValidatorTest extends TestCase
     {
         // given
         $value = null;
-        $validator = new BaseValidator($value, 'Empty String');
 
         try {
             // when
-            $validator
+            BaseValidator::getInstance()
+                ->check($value, 'Empty String')
                 ->isString()
                 ->validate();
 
@@ -177,10 +175,12 @@ class BaseValidatorTest extends TestCase
     {
         // given
         $value = null;
-        $validator = new BaseValidator($value, 'Empty String');
 
         // when
-        $result = $validator->isStringOrEmpty()->validate();
+        $result = BaseValidator::getInstance()
+            ->check($value, 'Empty String')
+            ->isStringOrEmpty()
+            ->validate();
 
         self::assertTrue($result);
     }
@@ -192,10 +192,10 @@ class BaseValidatorTest extends TestCase
     {
         // given
         $arr = [];
-        $validator = new BaseValidator($arr, $this->name);
 
         // when
-        $result = $validator
+        $result = BaseValidator::getInstance()
+            ->check($arr, $this->name)
             ->isArray()
             ->validate();
 
@@ -209,11 +209,11 @@ class BaseValidatorTest extends TestCase
     {
         // given
         $value = 1;
-        $validator = new BaseValidator($value, $this->name);
 
         try {
             // when
-            $validator
+            BaseValidator::getInstance()
+                ->check($value, $this->name)
                 ->isArray()
                 ->validate();
 
@@ -232,10 +232,10 @@ class BaseValidatorTest extends TestCase
     {
         // given
         $value = 1;
-        $validator = new BaseValidator($value, $this->name);
 
         // when
-        $result = $validator
+        $result = BaseValidator::getInstance()
+            ->check($value, $this->name)
             ->isInteger()
             ->validate();
 
@@ -249,11 +249,11 @@ class BaseValidatorTest extends TestCase
     {
         // given
         $value = '';
-        $validator = new BaseValidator($value, $this->name);
 
         try {
             // when
-            $validator
+            BaseValidator::getInstance()
+                ->check($value, $this->name)
                 ->isInteger()
                 ->validate();
 
@@ -274,10 +274,9 @@ class BaseValidatorTest extends TestCase
         $stringValue = 'A String';
         $intValue = 42;
         $arrayValues = ['foo', 'bar'];
-        $validator = new BaseValidator();
 
         // when
-        $result = $validator
+        $result = BaseValidator::getInstance()
             ->check($stringValue, 'String')->isString()
             ->check($intValue, 'Integer')->isInteger()
             ->check($arrayValues, 'Array')->isArray()
@@ -295,11 +294,10 @@ class BaseValidatorTest extends TestCase
         // given
         $stringValue = 'A String';
         $arrayValues = ['foo', 'bar'];
-        $validator = new BaseValidator();
 
         try {
             // when
-            $validator
+            BaseValidator::getInstance()
                 ->check($stringValue, 'String')->isString()
                 ->check($arrayValues, 'Wrong')->isInteger()
                 ->check($arrayValues, 'Array')->isArray()
@@ -320,10 +318,9 @@ class BaseValidatorTest extends TestCase
     {
         // given
         $url = '/a/relative/url';
-        $validator = new BaseValidator();
 
         // when
-        $result = $validator
+        $result = BaseValidator::getInstance()
             ->check($url, 'relative url')
             ->isRelativeUrl()
             ->validate();
@@ -339,11 +336,10 @@ class BaseValidatorTest extends TestCase
     {
         // given
         $url = 'https://na.finalfantasxiv.com/a/simple/test';
-        $validator = new BaseValidator();
 
         try {
             // when
-            $validator
+            BaseValidator::getInstance()
                 ->check($url, 'Absolute Url')
                 ->isRelativeUrl()
                 ->validate();

--- a/tests/Lodestone/Validator/HttpRequestValidatorTest.php
+++ b/tests/Lodestone/Validator/HttpRequestValidatorTest.php
@@ -20,10 +20,10 @@ class HttpRequestValidatorTest extends TestCase
     {
         // given
         $httpCode = 200;
-        $validator = new HttpRequestValidator($httpCode, 'test http code');
 
         // when
-        $result = $validator
+        $result = HttpRequestValidator::getInstance()
+            ->check($httpCode, 'test http code')
             ->isNotHttpError()
             ->validate();
 
@@ -37,13 +37,13 @@ class HttpRequestValidatorTest extends TestCase
     {
         // given
         $httpCode = 199;
-        $validator = new HttpRequestValidator($httpCode, 'test http code');
 
         try {
             // when
-            $validator
-            ->isNotHttpError()
-            ->validate();
+            HttpRequestValidator::getInstance()
+                ->check($httpCode, 'test http code')
+                ->isNotHttpError()
+                ->validate();
 
             self::fail("Expected ValidationException");
         } catch(ValidationException $vex) {
@@ -59,13 +59,13 @@ class HttpRequestValidatorTest extends TestCase
     {
         // given
         $httpCode = 309;
-        $validator = new HttpRequestValidator($httpCode, 'test http code');
 
         try {
             // when
-            $validator
-            ->isNotHttpError()
-            ->validate();
+            HttpRequestValidator::getInstance()
+                ->check($httpCode, 'test http code')
+                ->isNotHttpError()
+                ->validate();
 
             self::fail("Expected ValidationException");
         } catch(ValidationException $vex) {


### PR DESCRIPTION
This is a continuation of #30

## Move Initialization into IF-constructs

I moved a few things into their respective if statements. An Example:

```php
 // add mirage
$mirageId = false;
$mirageNode = $node->find('.db-tooltip__item__mirage');
if ($mirageNode) {
  $mirageNode = $mirageNode->find('a', 0);
  if ($mirageNode) {
    $mirageId = explode('/', $mirageNode->getAttribute('href'))[5];
    // todo - parse name and convert to ingame id
  }
}
$item->setMirageId($mirageId);
```

is now:

```php
 // add mirage
$mirageNode = $node->find('.db-tooltip__item__mirage');
if ($mirageNode) {
  $mirageNode = $mirageNode->find('a', 0);
  if ($mirageNode) {
    $mirageId = explode('/', $mirageNode->getAttribute('href'))[5];
    $item->setMirageId($mirageId);
    // todo - parse name and convert to ingame id
  }
}
```

This saves a few function calls :)


## also transforms validators into singletons.
After 10 runs of cli.php there was a save of 0.004ms after changing the validator

Can you validate it @viion?

