### PR TITLE
SIlence real IDs and FC check

### DIFF
--- a/src/Lodestone/Modules/XIVDBDataTrait.php
+++ b/src/Lodestone/Modules/XIVDBDataTrait.php
@@ -94,7 +94,7 @@ trait XIVDBDataTrait
 
         Benchmark::finish($method,__LINE__);
 
-        return $json[$hash];
+        return (isset($json[$hash]) ? $json[$hash] : 0);
     }
 
     /**
@@ -117,7 +117,7 @@ trait XIVDBDataTrait
     public function getClassJobName($id)
     {
         $json = $this->getData('classjobs2');
-        return $json[$id];
+        return (isset($json[$id]) ? $json[$id] : 0);
     }
 
     /**
@@ -190,6 +190,6 @@ trait XIVDBDataTrait
         $hash = $this->getStorageHash($name);
         $json = $this->getData($index);
 
-        return $json[$hash];
+        return (isset($json[$hash]) ? $json[$hash] : 0);
     }
 }

--- a/src/Lodestone/Parser/Character/TraitProfile.php
+++ b/src/Lodestone/Parser/Character/TraitProfile.php
@@ -221,7 +221,7 @@ trait TraitProfile
         $html = $this->getArrayFromRange('Free Company', 1, $html);
 
         // not all characters have a free company
-        if ($html[1]) {
+        if (isset($html[1])) {
             $url = trim(explode('/', $html[1])[3]);
             $this->profile->setFreecompany($url);
         }

--- a/src/Lodestone/Parser/Character/TraitProfile.php
+++ b/src/Lodestone/Parser/Character/TraitProfile.php
@@ -49,11 +49,13 @@ trait TraitProfile
 
         $html = $this->getArrayFromRange('frame__chara', 'parts__connect--state');
 
-        // name + servers
-        list($name, $server) = $this->getArrayFromRange('frame__chara__name', 1, $html);
-        $this->profile
-            ->setName(trim(strip_tags($name)))
-            ->setServer(trim(strip_tags($server)));
+        //name
+        $name = $this->getArrayFromRange('frame__chara__name', 0, $html);
+        $this->profile->setName(trim(strip_tags($name[0])));
+        
+        //server
+        $server = $this->getArrayFromRange('frame__chara__world', 0, $html);
+        $this->profile->setServer(trim(strip_tags($server[0])));
 
         // title
         $title = $this->getArrayFromRange('frame__chara__title', 0, $html);


### PR DESCRIPTION
Prevents warnings in case hash (or id) is not found in data.php by enforcing 0 in case index is not set. Especially helpful when data in XIVDB and Lodestone differ in regards to names.
Same as with check for GC, added isset to prevent notices