### PR TITLE
Add achievements categories

### DIFF
--- a/src/Lodestone/Api.php
+++ b/src/Lodestone/Api.php
@@ -158,16 +158,17 @@ class Api
     /**
      * @test 730968
      * @param $id
-     * @param int $category
+     * @param int $type = 1
+     * @param bool $includeUnobtained = false
+     * @param int $category = false
      * @return Entities\Character\Achievements
      */
     public function getCharacterAchievements($id, $type = 1, $includeUnobtained = false, $category = false)
     {
-        if ($category) {
-            $url = sprintf(Routes::LODESTONE_ACHIEVEMENTS_CAT_URL, $id, $type);
-        } else {
-            $url = sprintf(Routes::LODESTONE_ACHIEVEMENTS_URL, $id, $type);
-        }
+        $url = $category === false
+            ? sprintf(Routes::LODESTONE_ACHIEVEMENTS_CAT_URL, $id, $type)
+            : sprintf(Routes::LODESTONE_ACHIEVEMENTS_URL, $id, $type);
+
         return (new AchievementsParser($type))->url($url)->parse($includeUnobtained);
     }
 

--- a/src/Lodestone/Api.php
+++ b/src/Lodestone/Api.php
@@ -161,10 +161,14 @@ class Api
      * @param int $category
      * @return Entities\Character\Achievements
      */
-    public function getCharacterAchievements($id, $category = 1, $includeUnobtained = false)
+    public function getCharacterAchievements($id, $type = 1, $includeUnobtained = false, $category = false)
     {
-        $url = sprintf(Routes::LODESTONE_ACHIEVEMENTS_URL, $id, $category);
-        return (new AchievementsParser($category))->url($url)->parse($includeUnobtained);
+        if ($category) {
+            $url = sprintf(Routes::LODESTONE_ACHIEVEMENTS_CAT_URL, $id, $type);
+        } else {
+            $url = sprintf(Routes::LODESTONE_ACHIEVEMENTS_URL, $id, $type);
+        }
+        return (new AchievementsParser($type))->url($url)->parse($includeUnobtained);
     }
 
     /**

--- a/src/Lodestone/Modules/Http/Routes.php
+++ b/src/Lodestone/Modules/Http/Routes.php
@@ -21,6 +21,7 @@ class Routes
     const LODESTONE_CHARACTERS_FOLLOWING_URL = self::LODESTONE_URL . 'lodestone/character/%s/following';
     const LODESTONE_CHARACTERS_SEARCH_URL = self::LODESTONE_URL .'lodestone/character';
     const LODESTONE_ACHIEVEMENTS_URL = self::LODESTONE_URL . 'lodestone/character/%s/achievement/kind/%s/';
+    const LODESTONE_ACHIEVEMENTS_CAT_URL = self::LODESTONE_URL . 'lodestone/character/%s/achievement/category/%s/';
 
     // free company
     const LODESTONE_FREECOMPANY_URL = self::LODESTONE_URL . 'lodestone/freecompany/%s/';


### PR DESCRIPTION
Small change to allow parsing of achievements subcategories (called just "categories" on Lodestone)